### PR TITLE
fix: update angular config to bundle assests folder and update image file references

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -16,14 +16,16 @@
             "outputPath": "dist/cms",
             "index": "src/index.html",
             "browser": "src/main.ts",
-            "polyfills": [
-              "zone.js"
-            ],
+            "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "assets": [
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "**/*",
+                "input": "src/assets"
               }
             ],
             "styles": [
@@ -74,10 +76,7 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": [
-              "zone.js",
-              "zone.js/testing"
-            ],
+            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "tsconfig.spec.json",
             "assets": [
               {
@@ -85,9 +84,7 @@
                 "input": "public"
               }
             ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "styles": ["src/styles.css"],
             "scripts": []
           }
         }

--- a/src/app/contacts/contact-list/contact-list.component.ts
+++ b/src/app/contacts/contact-list/contact-list.component.ts
@@ -1,17 +1,31 @@
 import { Component } from '@angular/core';
 import { Contact } from '../contact.model';
-import { NgFor } from '@angular/common'; 
+import { NgFor } from '@angular/common';
 
 @Component({
   selector: 'cms-contact-list',
   standalone: true,
-  imports: [NgFor],  
+  imports: [NgFor],
   templateUrl: './contact-list.component.html',
-  styleUrls: ['./contact-list.component.css']
+  styleUrls: ['./contact-list.component.css'],
 })
 export class ContactListComponent {
   contacts: Contact[] = [
-    new Contact("1", "R. Kent Jackson", "jacksonk@byui.edu", "208-496-3771", "assets/images/jacksonk.jpg", null),
-    new Contact("2", "Rex Barzee", "barzeer@byui.edu", "208-496-3768", "assets/images/barzeer.jpg", null)
+    new Contact(
+      '1',
+      'R. Kent Jackson',
+      'jacksonk@byui.edu',
+      '208-496-3771',
+      'images/jacksonk.jpg',
+      null
+    ),
+    new Contact(
+      '2',
+      'Rex Barzee',
+      'barzeer@byui.edu',
+      '208-496-3768',
+      'images/barzeer.jpg',
+      null
+    ),
   ];
 }


### PR DESCRIPTION
We need to add a config for the assets folder in order to properly load images in our app. Angular is going to use this config to know what it needs to bundle. With this config we are able to reference the image at its bundled location which in this case will be images/filename.ext